### PR TITLE
Use Trade Report For Everything

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby-experian (0.1.0)
+    ruby-experian (0.1.1)
       faraday (>= 1)
       multi_xml (>= 0.6.0)
       rexml (>= 3.2)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Experian.configure do |config|
 end
 ```
 
+By default, this gem will look for the environment variables `EXPERIAN_USER_CODE` and `EXPERIAN_PASSWORD` to set the default values for user code and password.
+
 Then you can create a client like this:
 
 ```ruby
@@ -122,9 +124,9 @@ You can further configure the faraday connection by passing in a block to the cl
   end
 ```
 
-### Report
+### Credit Report
 
-You can hit the report api to get the 360 credit report from Experian by passing in a CIF to the call. Note that only some sections of the report are exposed. Other sections will be exposed as needed / requested.
+You can hit the credit report api to get the 360 credit report from Experian by passing in a CIF to the call. Note that only some sections of the report are exposed. Other sections will be exposed as needed / requested.
 
 The exposed sections for now are:
 
@@ -133,9 +135,29 @@ The exposed sections for now are:
 - rating
 - number_of_employees
 - cnae
+- constitution_date
 
 ```ruby
-report = client.report(cif: "cif goes here")
+report = client.credit_report(cif: "cif goes here")
+report.rating.inspect
+# => "#<OpenStruct score=8, default_probability=0.529, risk=\"Mínimo\", size=\"Grande\">"
+```
+
+### Trade Report
+
+You can hit the trade report api to get the 360 trade report from Experian by passing in a CIF to the call. Note that only some sections of the report are exposed. Other sections will be exposed as needed / requested.
+
+The exposed sections for now are:
+
+- model_200(period:)
+- address
+- rating
+- most_recent_number_of_employees
+- cnae
+- constitution_date
+
+```ruby
+report = client.trade_report(cif: "cif goes here")
 report.rating.inspect
 # => "#<OpenStruct score=8, default_probability=0.529, risk=\"Mínimo\", size=\"Grande\">"
 ```

--- a/bin/console
+++ b/bin/console
@@ -4,6 +4,7 @@ require "bundler/setup"
 require "experian"
 require "pry"
 require "pry-byebug"
+require "dotenv/load"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/experian.rb
+++ b/lib/experian.rb
@@ -21,8 +21,8 @@ module Experian
     DEFAULT_REQUEST_TIMEOUT = 120
 
     def initialize
-      @user_code = nil
-      @password = nil
+      @user_code = ENV.fetch("EXPERIAN_USER_CODE", nil)
+      @password = ENV.fetch("EXPERIAN_PASSWORD", nil)
       @version = DEFAULT_VERSION
       @request_timeout = DEFAULT_REQUEST_TIMEOUT
       @base_uri = DEFAULT_BASE_URI

--- a/lib/experian/trade_report.rb
+++ b/lib/experian/trade_report.rb
@@ -38,6 +38,44 @@ module Experian
       }
     end
 
+    def constitution_date
+      date = data.dig("SeccionDatosRegistrales", "FechaConstitucion")
+      date && Date.parse(date)
+    end
+
+    def address
+      if (address_xml = data["SeccionDatosRegistrales"]["DomicilioSocial"])
+        OpenStruct.new(
+          line: address_xml["Domicilio"],
+          city: address_xml["Poblacion"] || address_xml["Provincia"],
+          province: address_xml["Provincia"],
+          postal_code: address_xml["CodigoPostal"],
+          municipality: address_xml["Municipio"],
+        )
+      end
+    end
+
+    def most_recent_number_of_employees
+      data.dig("ListaAnualEmpleados", "Empleado").first&.dig("EmpleadoFijo")&.to_i
+    end
+
+    def cnae
+      data.dig("ActividadComercial", "Cnae")&.first&.dig("Codigo")&.to_i
+    end
+
+    def rating
+      if (rating_xml = data["Rating"])
+        return unless rating_xml["RatingAxesorDef"]
+
+        OpenStruct.new(
+          score: rating_xml["RatingAxesorDef"]&.strip&.to_i,
+          default_probability: rating_xml["ProbImpago"]&.to_f,
+          risk: rating_xml["GrupoRiesgo"],
+          size: rating_xml["Tamaño"],
+        )
+      end
+    end
+
     private
 
     def last_submitted_year

--- a/lib/experian/version.rb
+++ b/lib/experian/version.rb
@@ -1,3 +1,3 @@
 module Experian
-  VERSION = "0.1.0".freeze
+  VERSION = "0.1.1".freeze
 end

--- a/spec/experian/trade_report_spec.rb
+++ b/spec/experian/trade_report_spec.rb
@@ -76,4 +76,43 @@ RSpec.describe Experian::TradeReport do
       })
     end
   end
+
+  it ".most_recent_number_of_employees" do
+    expect(report.most_recent_number_of_employees).to eq(144)
+  end
+
+  it ".cnae" do
+    expect(report.cnae).to eq(6311)
+  end
+
+  it ".constitution_date" do
+    expect(report.constitution_date).to eq(Date.parse("08/03/1996"))
+  end
+
+  it ".rating" do
+    allow(report).to receive(:data).and_return({
+      "Rating" => {
+        "RatingAxesorDef" => "8 ",
+        "ProbImpago" => "0.56",
+        "GrupoRiesgo" => "Bajo",
+        "Tamaño" => "Grande"
+      }
+    })
+    expect(report.rating).to have_attributes(
+      score: 8,
+      default_probability: 0.56,
+      risk: "Bajo",
+      size: "Grande",
+    )
+  end
+
+  it ".address" do
+    expect(report.address).to have_attributes(
+      line: "PARQUE EMPRESARIAL SAN ISIDRO, S/N - EDIFICIO AXESOR",
+      city: "ARMILLA",
+      province: "GRANADA",
+      postal_code: nil, # comes as nil in the report
+      municipality: "ARMILLA"
+    )
+  end
 end

--- a/spec/experian_spec.rb
+++ b/spec/experian_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Experian do
   it "has a version number" do
-    expect(Experian::VERSION).to eq "0.1.0"
+    expect(Experian::VERSION).to eq "0.1.1"
   end
 
   describe "#configure" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,9 @@ if ENV["COVERAGE_DIR"]
 end
 
 require "bundler/setup"
-require "dotenv/load"
+require "dotenv"
+Dotenv.load(".env.test")
+
 require "experian"
 Bundler.require(:default, :development, :test)
 


### PR DESCRIPTION
Modifies the trade report to expose all the information exposed by the credit report. This way we don't have to consume 2 credits.

## All Submissions:

- [x] Have you followed the guidelines in our [Contributing document](../blob/main/CONTRIBUTING.md)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
